### PR TITLE
Fjerne VCR dependency

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,3 @@
 require 'rdf/spec'
 require 'rdf'
 require 'rdf/virtuoso'
-#require 'active_rdf'
-require 'vcr'
-
-VCR.configure do |c|
-  c.cassette_library_dir = 'fixtures/cassettes'
-  c.hook_into :webmock
-end
-
-Dir[File.expand_path('../../spec/support/**/*.rb', File.path(__FILE__))].each { |f| require f }


### PR DESCRIPTION
Dette kan vel trygt fjernes?
vcr er ikke i gemspec, så rspec feiler hvis ikke du har gem vcr installert
