### PR TITLE
Bump httparty version to remove transitive dependency

### DIFF
--- a/rdf-virtuoso.gemspec
+++ b/rdf-virtuoso.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'rdf', '>= 3.1'
-  s.add_runtime_dependency 'httparty', '~> 0.12.0'
+  s.add_runtime_dependency 'httparty', '~> 0.18.1'
   s.add_runtime_dependency 'api_smith', '~> 1.3.0'
 
   s.add_development_dependency 'rspec', '~> 3.10'


### PR DESCRIPTION
...on old, vulnerable json gem version (1.8.6)