### PR TITLE
GitHub testing with virtuoso service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
+      VIRTUOSO_INTEGRATION_TESTS: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: bundle install --jobs 4 --retry 3
       - name: Wait to give Virtuoso a little extra time
-        uses: jakejarvis/wait-action@master
+        uses: juliangruber/sleep-action@v1
         with:
           time: '3s'
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ jobs:
           - 3.0
           - ruby-head # Eventualy
           - jruby
+    services: 
+      virtuoso:
+        image: tenforce/virtuoso
+        env:
+          DBA_PASSWORD: tester
+          SPARQL_UPDATE: true
+          DEFAULT_GRAPH: test:graph
+        ports:
+          - 8890:8890
+          - 1111:1111
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
         image: tenforce/virtuoso
         env:
           DBA_PASSWORD: tester
-          SPARQL_UPDATE: true
-          DEFAULT_GRAPH: test:graph
+          SPARQL_UPDATE: true          
         ports:
           - 8890:8890
           - 1111:1111

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: bundle install --jobs 4 --retry 3
       - name: Wait to give Virtuoso a little extra time
-        run: jakejarvis/wait-action@master
+        uses: jakejarvis/wait-action@master
         with:
           time: '3s'
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies
         run: bundle install --jobs 4 --retry 3
+      - name: Wait to give Virtuoso a little extra time
+        run: jakejarvis/wait-action@master
+        with:
+          time: '3s'
       - name: Run tests
         run: bundle exec rspec spec
  

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -46,8 +46,8 @@ describe RDF::Virtuoso::Repository do
       repository.delete(query)
     end
 
-    # it_behaves_like "an RDF::Repository" do
-    #     let(:repository) {subject}
-    # end
+    # commented out until conformance issues are resolved, otherwise there are many errors
+    # it_behaves_like "an RDF::Repository"        
+
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,0 +1,32 @@
+$:.unshift "."
+require File.join(File.dirname(__FILE__), 'spec_helper')
+require 'rdf/spec/repository'
+
+# these tests rely on a Virtuoso instance being available, at port 8890, and will otherwise fail
+# the easiest way to do this is with docker ( https://docs.docker.com/get-docker/ ), running the following:
+#   docker run -p 8890:8890 -p 1111:1111 -e DBA_PASSWORD=tester -e SPARQL_UPDATE=true --name virtuoso-testing -d tenforce/virtuoso
+# when finished you can stop with
+#   docker stop virtuoso-testing
+
+describe RDF::Virtuoso::Repository do
+    context('when interating with a virtuoso repository instance') do
+        let(:uri) {"http://localhost:8890/sparql"}
+        let(:update_uri) {"http://localhost:8890/sparql-auth"}
+        let(:repo) {RDF::Virtuoso::Repository.new(uri)}
+        let(:password) {'tester'}
+        let(:username) {'dba'}
+        let(:repo) {
+            RDF::Virtuoso::Repository.new(uri,
+                update_uri: update_uri,
+                username: username,
+                password: password,
+                auth_method: 'digest')                
+        }
+
+        it 'should be able to select' do           
+            query = RDF::Virtuoso::Query.select.where([RDF::Resource('http://localhost:8890/sparql'), :p, :o])
+            expect(repo.select(query).count).to eql 14
+        end
+    end
+end
+    

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -27,5 +27,9 @@ describe RDF::Virtuoso::Repository do
       query = RDF::Virtuoso::Query.select.where([RDF::Resource('http://localhost:8890/sparql'), :p, :o])
       expect(repo.select(query).count).to eql 14
     end
+
+    it_behaves_like "an RDF::Repository" do
+        let(:repository) {repo}
+    end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -4,14 +4,19 @@ $LOAD_PATH.unshift '.'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/repository'
 
-# these tests rely on a Virtuoso instance being available, at port 8890, and will otherwise fail
+# these tests rely on a Virtuoso service being available, at port 8890
 # the easiest way to do this is with docker ( https://docs.docker.com/get-docker/ ), running the following:
 #   docker run -p 8890:8890 -p 1111:1111 -e DBA_PASSWORD=tester -e SPARQL_UPDATE=true --name virtuoso-testing -d tenforce/virtuoso
 # when finished you can stop with
 #   docker stop virtuoso-testing
+#
+# to avoid the tests being skipped, you will need to set the environment variable VIRTUOSO_INTEGRATION_TESTS, e.g.
+#   VIRTUOSO_INTEGRATION_TESTS=true bundle exec rspec spec
 
-describe RDF::Virtuoso::Repository do
-  context('when interacting with a virtuoso repository instance') do
+skip = ENV['VIRTUOSO_INTEGRATION_TESTS'] ? false : 'Skipping Integration tests against a running repository, see spec/integration_spec.rb'
+
+describe RDF::Virtuoso::Repository, skip: skip do
+  context('when interacting with a virtuoso repository service') do
     subject(:repository) do
       described_class.new(uri,
                           update_uri: update_uri,
@@ -28,7 +33,6 @@ describe RDF::Virtuoso::Repository do
 
     it 'is able to select' do
       # check a single triple result which is unlikely to change
-
       query = RDF::Virtuoso::Query.select.where([RDF::URI('http://localhost:8890/sparql'),
                                                  RDF::URI('http://www.w3.org/ns/sparql-service-description#endpoint'), :o])
 
@@ -47,7 +51,6 @@ describe RDF::Virtuoso::Repository do
     end
 
     # commented out until conformance issues are resolved, otherwise there are many errors
-    # it_behaves_like "an RDF::Repository"        
-
+    # it_behaves_like "an RDF::Repository"
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift '.'
-require File.join(File.dirname(__FILE__), 'spec_helper')
+require_relative 'spec_helper'
 require 'rdf/spec/repository'
 
 # these tests rely on a Virtuoso service being available, at port 8890

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -28,8 +28,9 @@ describe RDF::Virtuoso::Repository do
       expect(repo.select(query).count).to eql 14
     end
 
-    it_behaves_like "an RDF::Repository" do
-        let(:repository) {repo}
-    end
+    # it_behaves_like "an RDF::Repository" do
+    #     let(:repository) {repo}
+    # end
+
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,4 +1,4 @@
-$:.unshift "."
+$:.unshift '.'
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'rdf/spec/repository'
 
@@ -9,24 +9,23 @@ require 'rdf/spec/repository'
 #   docker stop virtuoso-testing
 
 describe RDF::Virtuoso::Repository do
-    context('when interating with a virtuoso repository instance') do
-        let(:uri) {"http://localhost:8890/sparql"}
-        let(:update_uri) {"http://localhost:8890/sparql-auth"}
-        let(:repo) {RDF::Virtuoso::Repository.new(uri)}
-        let(:password) {'tester'}
-        let(:username) {'dba'}
-        let(:repo) {
-            RDF::Virtuoso::Repository.new(uri,
-                update_uri: update_uri,
-                username: username,
-                password: password,
-                auth_method: 'digest')                
-        }
-
-        it 'should be able to select' do           
-            query = RDF::Virtuoso::Query.select.where([RDF::Resource('http://localhost:8890/sparql'), :p, :o])
-            expect(repo.select(query).count).to eql 14
-        end
+  context('when interating with a virtuoso repository instance') do
+    let(:uri) { 'http://localhost:8890/sparql' }
+    let(:update_uri) { 'http://localhost:8890/sparql-auth' }
+    let(:repo) { RDF::Virtuoso::Repository.new(uri) }
+    let(:password) { 'tester' }
+    let(:username) { 'dba' }
+    let(:repo) do
+      RDF::Virtuoso::Repository.new(uri,
+                                    update_uri: update_uri,
+                                    username: username,
+                                    password: password,
+                                    auth_method: 'digest')
     end
+
+    it 'should be able to select' do
+      query = RDF::Virtuoso::Query.select.where([RDF::Resource('http://localhost:8890/sparql'), :p, :o])
+      expect(repo.select(query).count).to eql 14
+    end
+  end
 end
-    


### PR DESCRIPTION
I'll submit this now as a PR towards addressing issue #15 

It includes an extension to the Github CI workflow to include the virtuoso docker service. There is then also a new spec (named integration_spec.rb, but maybe this should go in repository_spec.rb with its own concern, I'm not clear on rspec conventions with these types of integration tests) which is configured to setup an `RDF::Virtuoso::Repository` to connect to the docker service.

There are a couple of sanity tests to check that a select and insert can be successfully made against the docker service.

I've also added a call to `it_behaves_like "an RDF::Repository"` for the conformance tests - however this is currently commented out as it raised many errors. It may take some time to fix all of these, but since many seem to have a similar error it is possible they all have a common cause.

The tests are skipped unless the env variable `VIRTUOSO_INTEGRATION_TESTS` exists, which is set in the CI workflow, and there are instructions on how to run locally within the spec file.